### PR TITLE
Add additional parser decimal error match types

### DIFF
--- a/src/parse/parser.rs
+++ b/src/parse/parser.rs
@@ -12,6 +12,8 @@ fn decimal_err_into_str(err: Error) -> &'static str {
             "precision necessary to represent exceeds the maximum possible"
         }
         Error::ErrorString(_) => "cannot parse as decimal (unable to display root cause)",
+        Error::Underflow => "cannot parse as decimal (unable to display root cause)",
+        Error::ConversionTo(_) => "cannot parse as decimal (unable to display root cause)",
     }
 }
 


### PR DESCRIPTION
Thanks for publishing svg2gcode! I'm planning to use it in a personal web app and came upon this error when building:
```
   Compiling g-code v0.3.3 (/Users/xxx/git/g-code)
error[E0004]: non-exhaustive patterns: `rust_decimal::Error::Underflow` and `rust_decimal::Error::ConversionTo(_)` not covered
  --> src/parse/parser.rs:4:11
   |
4  |     match err {
   |           ^^^ patterns `rust_decimal::Error::Underflow` and `rust_decimal::Error::ConversionTo(_)` not covered
   |
note: `rust_decimal::Error` defined here
  --> /Users/xxx/.cargo/registry/src/github.com-1ecc6299db9ec823/rust_decimal-1.28.1/src/error.rs:18:5
   |
7  | pub enum Error {
   | --------------
...
18 |     Underflow,
   |     ^^^^^^^^^ not covered
...
23 |     ConversionTo(String),
   |     ^^^^^^^^^^^^ not covered
   = note: the matched value is of type `rust_decimal::Error`
help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern, a match arm with multiple or-patterns as shown, or multiple match arms
   |
14 ~         Error::ErrorString(_) => "cannot parse as decimal (unable to display root cause)",
15 ~         rust_decimal::Error::Underflow | rust_decimal::Error::ConversionTo(_) => todo!(),
   |

For more information about this error, try `rustc --explain E0004`.
error: could not compile `g-code` due to previous error
```

I'm new to Rust so not really sure if there is a way to bypass it, otherwise it looks like it just needs a couple extra match cases, so I added them. Feel free to change the error message or the logic, just hoping this is useful :)